### PR TITLE
Add FLASK_SKIP_DOTENV=1 

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,2 +1,3 @@
-FLASK_APP=app
 APP_SETTINGS=config.DevelopmentConfig
+FLASK_APP=app
+FLASK_SKIP_DOTENV=1


### PR DESCRIPTION
To env so that flask doesn't display an incorrect tip for our env

```
* Tip: There are .env files present. Do "pip install python-dotenv" to use them.
```

But these are actually loaded by pipenv. See: https://github.com/pallets/flask/issues/2722