### PR TITLE
Restructure app.py to avoid cyclic dependencies

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,23 +1,16 @@
 import os
 
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
-from flask_jwt_extended import JWTManager
 
-app = Flask(__name__)
-app.config.from_object(os.environ['APP_SETTINGS'])
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-app.config['JWT_SECRET_KEY'] = 'super-secret'
 
-db = SQLAlchemy(app=app)
-migrate = Migrate(app=app, db=db)
+def create_app():
+    app = Flask(__name__)
+    app.config.from_object(os.environ['APP_SETTINGS'])
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.config['JWT_SECRET_KEY'] = 'super-secret'
 
-jwt = JWTManager(app)
+    from . import routes, models
+    routes.init_app(app)
+    models.init_app(app)
 
-#pylint: disable=wrong-import-position
-from app.routes.auth_routes import auth_blueprint
-from app.routes.project_routes import project_blueprint
-
-app.register_blueprint(auth_blueprint)
-app.register_blueprint(project_blueprint)
+    return app

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,11 @@
+from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
+
+db = SQLAlchemy()
+migrate = Migrate()
+
+
+def init_app(app):
+    app.app_context().push()
+    db.init_app(app)
+    migrate.init_app(app, db)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB
 
-from app import db
+from . import db
 
 vendor_type_enum = db.Enum(
     'admin',
@@ -51,6 +51,10 @@ class Project(db.Model):
     project_type = db.Column(project_type_enum, nullable=False)
     plastics = db.relationship('ProjectPlasticMap', back_populates='project')
     meta_data = db.Column(JSONB)
+
+    def save(self):
+        db.session.add(self)
+        db.session.commit()
 
 
 class Transaction(db.Model):

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,13 @@
+from flask_jwt_extended import JWTManager
+
+jwt = JWTManager()
+
+
+def init_app(app):
+    jwt.init_app(app)
+
+    from .auth_routes import auth_blueprint
+    from .project_routes import project_blueprint
+
+    app.register_blueprint(auth_blueprint)
+    app.register_blueprint(project_blueprint)

--- a/backend/app/routes/auth_routes.py
+++ b/backend/app/routes/auth_routes.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 
 from flask import Blueprint, request
 from flask_jwt_extended import create_access_token
-from app.routes.route_utils import error_response, success
-from app import db_client
+from .route_utils import error_response, success
+from . import db_client
 
 auth_blueprint = Blueprint('auth', __name__)
 
@@ -20,5 +20,6 @@ def login():
         return error_response("User cannot be found")
 
     validity_time = timedelta(days=7)
-    access_token = create_access_token(identity=email, expires_delta=validity_time)
+    access_token = create_access_token(
+        identity=email, expires_delta=validity_time)
     return success(**{"access_token": access_token})

--- a/backend/app/routes/db_client.py
+++ b/backend/app/routes/db_client.py
@@ -1,11 +1,9 @@
-from app import db
-from app.models import Project, User
+from ..models.models import Project, User
 
 
 def save_project(formatted_data):
     new_project = Project(**formatted_data)
-    db.session.add(new_project)
-    db.session.commit()
+    new_project.save()
 
 
 def get_user(email):

--- a/backend/app/routes/project_routes.py
+++ b/backend/app/routes/project_routes.py
@@ -1,8 +1,8 @@
 from flask import Blueprint, jsonify, request
 from flask_cors import CORS
 from flask_jwt_extended import jwt_required
-from app.routes.route_utils import success
-from app import db_client
+from .route_utils import success
+from . import db_client
 
 project_blueprint = Blueprint('project', __name__)
 CORS(project_blueprint)

--- a/backend/migrations/versions/ada1700cd552_.py
+++ b/backend/migrations/versions/ada1700cd552_.py
@@ -6,7 +6,6 @@ Create Date: 2018-09-20 19:12:01.674448
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'ada1700cd552'

--- a/backend/tools/seed.py
+++ b/backend/tools/seed.py
@@ -5,8 +5,9 @@ A command line tool to create data on the database
 from pprint import pprint
 import click
 import bcrypt
-from app import db
-from app.models import User, Vendor, vendor_type_enum
+
+from app.models import db
+from app.models.models import User, Vendor, vendor_type_enum
 
 TABLE_CHOICE = ('user', 'vendor')
 
@@ -70,8 +71,8 @@ def _add_user():
         'active': click.prompt('Active [y/N]', type=bool),
         'password_hash': bcrypt.hashpw(
             click.prompt(
-                'Password', hide_input=True, confirmation_prompt=True)
-            .encode('utf8'), bcrypt.gensalt(14))
+                'Password', hide_input=True,
+                confirmation_prompt=True).encode('utf8'), bcrypt.gensalt(14))
     }
     params = {param: value for param, value in params.items() if value != ''}
     return User(**params)


### PR DESCRIPTION
We were declaring a lot of important vars like `db` and `blueprints` in `app.py`. The issue is that we also referenced it a ton in some child modules, which caused some headaches. I've restructured it so that we have an app factory `create_app` which just calls the `init_app` defined in the `__init__` file of every module. 

I'm pretty sure this runs (tested on my laptop), but I'd appreciate it if you guys tested it too, just in case. 