### PR TITLE
Removed Small Scrap Shop Wastepicker Option

### DIFF
--- a/frontend/src/components/DWCC/CreateWastePicker.js
+++ b/frontend/src/components/DWCC/CreateWastePicker.js
@@ -19,7 +19,6 @@ const wastePickerTypes = [
   { label: 'Home Basked Worker', value: 'home_based_worker' },
   { label: 'Itinerant Buyer', value: 'itinerant_buyer' },
   { label: 'Waste Picker Community Leader', value: 'wp_community_leader' },
-  { label: 'Small Scrap Shop', value: 'small_scrap_shop' },
 ];
 
 class CreateWastePicker extends Component {


### PR DESCRIPTION
Removed small scrap shop wastepicker option from waste picker type dropbox on create new wastepicker page.