### PR TITLE
Configure Redux DevTools extension

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,10 +7,13 @@ import rootReducer from './reducers';
 import App from './App';
 import { CookiesProvider } from 'react-cookie';
 
-const store = createStore(
-  rootReducer,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-);
+const store =
+  process.env.NODE_ENV === 'production'
+    ? createStore(rootReducer)
+    : createStore(
+        rootReducer,
+        window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+      );
 
 render(
   <CookiesProvider>


### PR DESCRIPTION
Allows the debugging of the Redux store with [Redux Dev Tools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd)

Configured the store following [these instructions](http://extension.remotedev.io/#11-basic-store) 

<img width="1440" alt="screen shot 2018-11-22 at 7 52 14 pm" src="https://user-images.githubusercontent.com/33774466/48925291-28158380-ee90-11e8-804a-acf5911ac16f.png">
