### PR TITLE
Joyce/dwcc name refactor

### DIFF
--- a/backend/app/models/vendor.py
+++ b/backend/app/models/vendor.py
@@ -6,7 +6,7 @@ from .mixins import BaseMixin
 vendor_type_enum = db.Enum(
     'admin',
     'wastepicker',
-    'dwcc',
+    'primary_segregator',
     'wholesaler',
     'manufacturer',
     name='vendor_type')
@@ -19,7 +19,7 @@ vendor_subtype_enum = db.Enum(
     'small_scrap_shop',
     'scrap_shop',
     'van_unit',
-    'dwcc',
+    'primary_segregator',
     'wholesaler',
     'export_wholesaler',
     'franchisee_partner',
@@ -35,9 +35,9 @@ vendor_subtype_map = {
     'itinerant_buyer': 'wastepicker',
     'wp_community_leader': 'wastepicker',
     'small_scrap_shop': 'wastepicker',
-    'scrap_shop': 'dwcc',
-    'van_unit': 'dwcc',
-    'dwcc': 'dwcc',
+    'scrap_shop': 'primary_segregator',
+    'van_unit': 'primary_segregator',
+    'primary_segregator': 'primary_segregator',
     'wholesaler': 'wholesaler',
     'export_wholesaler': 'wholesaler',
     'franchisee_partner': 'wholesaler',
@@ -65,10 +65,10 @@ class Vendor(BaseMixin, db.Model):
         return super().create(**kwargs)
 
 
-class DWCCWastepickerMap(BaseMixin, db.Model):
-    __tablename__ = 'dwcc_wastepicker_map'
+class PrimarySegregatorWastepickerMap(BaseMixin, db.Model):
+    __tablename__ = 'primary_segregator_wastepicker_map'
     wastepicker_id = db.Column(
         db.Integer, db.ForeignKey('vendor.id'), primary_key=True)
-    dwcc_id = db.Column(db.Integer, db.ForeignKey('vendor.id'))
-    __table_args__ = (db.Index('IX_dwcc_wastepicker_map_dwcc_id', dwcc_id),
-                      db.UniqueConstraint('dwcc_id', 'wastepicker_id'))
+    primary_segregator_id = db.Column(db.Integer, db.ForeignKey('vendor.id'))
+    __table_args__ = (db.Index('IX_primary_segregator_wastepicker_map_primary_segregator_id', primary_segregator_id),
+                      db.UniqueConstraint('primary_segregator_id', 'wastepicker_id'))

--- a/backend/app/routes/db_client.py
+++ b/backend/app/routes/db_client.py
@@ -4,7 +4,7 @@ from . import s3_client
 from ..models.project import Project
 from ..models.transaction import Transaction
 from ..models.user import User
-from ..models.vendor import DWCCWastepickerMap, Vendor
+from ..models.vendor import PrimarySegregatorWastepickerMap, Vendor
 
 
 # TODO(imran): write decorator to make db reads/writes atomic
@@ -50,10 +50,10 @@ def create_vendor(data, current_user=None, files=None):
     vendor = Vendor.create(**data)
 
     if current_user is not None \
-            and current_user['vendor']['vendor_type'] == 'dwcc' \
+            and current_user['vendor']['vendor_type'] == 'primary_segregator' \
             and vendor.vendor_type == 'wastepicker':
-        DWCCWastepickerMap.create(
-            dwcc_id=current_user['vendor_id'],
+        PrimarySegregatorWastepickerMap.create(
+            primary_segregator_id=current_user['vendor_id'],
             wastepicker_id=vendor.id)
     return vendor
 
@@ -70,8 +70,8 @@ def get_vendor_transactions(vendor_id):
             Transaction.to_vendor_id == vendor_id))
 
 
-def get_dwcc_associated_wastepickers(dwcc_id):
+def get_primary_segregator_associated_wastepickers(primary_segregator_id):
     return [
         entry.wastepicker_id
-        for entry in DWCCWastepickerMap.get_by(dwcc_id=dwcc_id)
+        for entry in PrimarySegregatorWastepickerMap.get_by(primary_segregator_id=primary_segregator_id)
     ]

--- a/backend/app/routes/vendor_routes.py
+++ b/backend/app/routes/vendor_routes.py
@@ -39,7 +39,7 @@ def create_vendor_transaction(vendor_id):
 
 
 # TODO(imran): Only certain vendor types should have the power to create
-# other vendor types. For example, DWCCs can only create other DWCCs.
+# other vendor types. For example, primary segregators can only create other primary segregators.
 # We should prevent vendors from creating other vendors inappropriately.
 # This requires having a `current_user` object.
 @blueprint.route('/', methods=['POST'])
@@ -55,8 +55,8 @@ def create_vendor():
     return success(data=vendor.to_dict(include_relationships=True))
 
 
-@blueprint.route('/dwcc/<int:dwcc_id>/wastepickers', methods=['GET'])
+@blueprint.route('/primary_segregator/<int:primary_segregator_id>/wastepickers', methods=['GET'])
 # @jwt_required
-def get_dwcc_associated_wastepickers(dwcc_id):
-    wastepicker_ids = db_client.get_dwcc_associated_wastepickers(dwcc_id)
+def get_primary_segregator_associated_wastepickers(primary_segregator_id):
+    wastepicker_ids = db_client.get_primary_segregator_associated_wastepickers(primary_segregator_id)
     return success(data=wastepicker_ids)

--- a/backend/migrations/versions/0619babf6bf9_change_vendor_type.py
+++ b/backend/migrations/versions/0619babf6bf9_change_vendor_type.py
@@ -1,0 +1,160 @@
+"""change vendor type
+
+Revision ID: 0619babf6bf9
+Revises: e52e3f9bce06
+Create Date: 2019-01-13 22:37:32.515599
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0619babf6bf9'
+down_revision = 'e52e3f9bce06'
+branch_labels = None
+depends_on = None
+
+vendor_type_name = 'vendor_type'
+vendor_type_temp_name = 'temp_' + vendor_type_name
+
+vendor_type_old_options = ('admin', 'wastepicker', 'dwcc',
+                           'wholesaler', 'manufacturer')
+vendor_type_inter_options = ('admin', 'wastepicker', 'dwcc', 'primary_segregator',
+                             'wholesaler', 'manufacturer')
+vendor_type_new_options = ('admin', 'wastepicker', 'primary_segregator',
+                           'wholesaler', 'manufacturer')
+
+vendor_type_old_type = sa.Enum(*vendor_type_old_options, name=vendor_type_name)
+vendor_type_inter_type = sa.Enum(*vendor_type_inter_options, name=vendor_type_name)
+vendor_type_new_type = sa.Enum(*vendor_type_new_options, name=vendor_type_name)
+
+vendor_type_inter_tcr = sa.sql.table('vendor',
+                                     sa.Column('vendor_type',
+                                               vendor_type_inter_type,
+                                               nullable=False))
+
+vendor_subtype_name = 'vendor_subtype'
+vendor_subtype_temp_name = 'temp_' + vendor_subtype_name
+
+vendor_subtype_old_options = ('wastepicker', 'home_based_worker', 'itinerant_buyer',
+                              'wp_community_leader', 'small_scrap_shop', 'scrap_shop',
+                              'van_unit', 'dwcc', 'wholesaler',
+                              'export_wholesaler', 'franchisee_partner', 'processor',
+                              'brand', 'admin')
+vendor_subtype_inter_options = ('wastepicker', 'home_based_worker', 'itinerant_buyer',
+                                'wp_community_leader', 'small_scrap_shop', 'scrap_shop',
+                                'van_unit', 'dwcc', 'primary_segregator', 'wholesaler',
+                                'export_wholesaler', 'franchisee_partner', 'processor',
+                                'brand', 'admin')
+vendor_subtype_new_options = ('wastepicker', 'home_based_worker', 'itinerant_buyer',
+                              'wp_community_leader', 'small_scrap_shop', 'scrap_shop',
+                              'van_unit', 'primary_segregator', 'wholesaler',
+                              'export_wholesaler', 'franchisee_partner', 'processor',
+                              'brand', 'admin')
+
+vendor_subtype_old_type = sa.Enum(*vendor_subtype_old_options, name=vendor_subtype_name)
+vendor_subtype_inter_type = sa.Enum(*vendor_subtype_inter_options, name=vendor_subtype_name)
+vendor_subtype_new_type = sa.Enum(*vendor_subtype_new_options, name=vendor_subtype_name)
+
+vendor_subtype_inter_tcr = sa.sql.table('vendor',
+                                        sa.Column('vendor_subtype',
+                                                  vendor_subtype_inter_type,
+                                                  nullable=False))
+
+
+def upgrade():
+    op.create_table('primary_segregator_wastepicker_map',
+                    sa.Column('wastepicker_id', sa.Integer(), nullable=False),
+                    sa.Column('primary_segregator_id', sa.Integer(), nullable=True),
+                    sa.ForeignKeyConstraint(['primary_segregator_id'], ['vendor.id'], ),
+                    sa.ForeignKeyConstraint(['wastepicker_id'], ['vendor.id'], ),
+                    sa.PrimaryKeyConstraint('wastepicker_id'),
+                    sa.UniqueConstraint('primary_segregator_id', 'wastepicker_id'))
+    op.create_index('IX_primary_segregator_wastepicker_map_primary_segregator_id',
+                    'primary_segregator_wastepicker_map', ['primary_segregator_id'], unique=False)
+    op.drop_index('IX_dwcc_wastepicker_map_dwcc_id', table_name='dwcc_wastepicker_map')
+    op.drop_table('dwcc_wastepicker_map')
+
+    op.execute('ALTER TYPE ' + vendor_type_name + ' RENAME TO ' + vendor_type_temp_name)
+    vendor_type_inter_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_type ' +
+               'TYPE ' + vendor_type_name + ' USING vendor_type::text::' + vendor_type_name)
+    op.execute(
+        vendor_type_inter_tcr.update()
+        .where(vendor_type_inter_tcr.c.vendor_type == 'dwcc')
+        .values(vendor_type='primary_segregator'))
+    op.execute('DROP TYPE ' + vendor_type_temp_name)
+    op.execute('ALTER TYPE ' + vendor_type_name + ' RENAME TO ' + vendor_type_temp_name)
+    vendor_type_new_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_type ' +
+               'TYPE ' + vendor_type_name + ' USING vendor_type::text::' +
+               vendor_type_name)
+    op.execute('DROP TYPE ' + vendor_type_temp_name)
+
+    op.execute('ALTER TYPE ' + vendor_subtype_name + ' RENAME TO ' + vendor_subtype_temp_name)
+    vendor_subtype_inter_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_subtype ' +
+               'TYPE ' + vendor_subtype_name + ' USING vendor_subtype::text::'
+               + vendor_subtype_name)
+    op.execute(
+        vendor_subtype_inter_tcr.update()
+        .where(vendor_subtype_inter_tcr.c.vendor_subtype == 'dwcc')
+        .values(vendor_subtype='primary_segregator'))
+    op.execute('DROP TYPE ' + vendor_subtype_temp_name)
+    op.execute('ALTER TYPE ' + vendor_subtype_name + ' RENAME TO ' + vendor_subtype_temp_name)
+    vendor_subtype_new_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_subtype ' +
+               'TYPE ' + vendor_subtype_name + ' USING vendor_subtype::text::' +
+               vendor_subtype_name)
+    op.execute('DROP TYPE ' + vendor_subtype_temp_name)
+
+
+def downgrade():
+    op.create_table('dwcc_wastepicker_map',
+                    sa.Column('wastepicker_id', sa.INTEGER(), autoincrement=False, nullable=False),
+                    sa.Column('dwcc_id', sa.INTEGER(), autoincrement=False, nullable=True),
+                    sa.ForeignKeyConstraint(['dwcc_id'], ['vendor.id'],
+                                            name='dwcc_wastepicker_map_dwcc_id_fkey'),
+                    sa.ForeignKeyConstraint(['wastepicker_id'], ['vendor.id'],
+                                            name='dwcc_wastepicker_map_wastepicker_id_fkey'),
+                    sa.PrimaryKeyConstraint('wastepicker_id', name='dwcc_wastepicker_map_pkey'),
+                    sa.UniqueConstraint('dwcc_id', 'wastepicker_id',
+                                        name='dwcc_wastepicker_map_dwcc_id_wastepicker_id_key'))
+    op.create_index('IX_dwcc_wastepicker_map_dwcc_id', 'dwcc_wastepicker_map', ['dwcc_id'],
+                    unique=False)
+    op.drop_index('IX_primary_segregator_wastepicker_map_primary_segregator_id',
+                  table_name='primary_segregator_wastepicker_map')
+    op.drop_table('primary_segregator_wastepicker_map')
+
+    op.execute('ALTER TYPE ' + vendor_type_name + ' RENAME TO ' + vendor_type_temp_name)
+    vendor_type_inter_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_type ' +
+               'TYPE ' + vendor_type_name + ' USING vendor_type::text::' + vendor_type_name)
+    op.execute(
+        vendor_type_inter_tcr.update()
+        .where(vendor_type_inter_tcr.c.vendor_type == 'primary_segregator')
+        .values(vendor_type='dwcc'))
+    op.execute('DROP TYPE ' + vendor_type_temp_name)
+    op.execute('ALTER TYPE ' + vendor_type_name + ' RENAME TO ' + vendor_type_temp_name)
+    vendor_type_old_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_type ' +
+               'TYPE ' + vendor_type_name + ' USING vendor_type::text::' + vendor_type_name)
+    op.execute('DROP TYPE ' + vendor_type_temp_name)
+
+    op.execute('ALTER TYPE ' + vendor_subtype_name + ' RENAME TO ' + vendor_subtype_temp_name)
+    vendor_subtype_inter_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_subtype ' +
+               'TYPE ' + vendor_subtype_name + ' USING vendor_subtype::text::' +
+               vendor_subtype_name)
+    op.execute(
+        vendor_subtype_inter_tcr.update()
+        .where(vendor_subtype_inter_tcr.c.vendor_subtype == 'primary_segregator')
+        .values(vendor_subtype='dwcc'))
+    op.execute('DROP TYPE ' + vendor_subtype_temp_name)
+    op.execute('ALTER TYPE ' + vendor_subtype_name + ' RENAME TO ' + vendor_subtype_temp_name)
+    vendor_subtype_old_type.create(op.get_bind())
+    op.execute('ALTER TABLE vendor ALTER COLUMN vendor_subtype ' +
+               'TYPE ' + vendor_subtype_name + ' USING vendor_subtype::text::' +
+               vendor_subtype_name)
+    op.execute('DROP TYPE ' + vendor_subtype_temp_name)

--- a/backend/tools/data/vendor.json
+++ b/backend/tools/data/vendor.json
@@ -1,7 +1,7 @@
 [
   {
     "vendor_subtype": "scrap_shop",
-    "name": "DWCC 1",
+    "name": "Primary Segregator 1",
     "metadata": {}
   },
   {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -57,7 +57,7 @@ class App extends React.Component {
   redirectUser(props) {
     if (this.props.isLoading) return null;
     if (this.isLoggedIn()) {
-      return this.props.currentUser.userType === 'dwcc' ? (
+      return this.props.currentUser.userType === 'primary_segregator' ? (
         <Redirect to={{ pathname: '/ps/transaction-history' }} />
       ) : (
         <Redirect to={{ pathname: '/landing' }} />
@@ -158,7 +158,9 @@ class App extends React.Component {
             </Switch>
             {this.props.currentUser && <LogoutButton cookies={this.props.cookies} />}
             {this.props.currentUser &&
-              this.props.currentUser.userType === 'dwcc' && <PrimarySegregatorBottomBar />}
+              this.props.currentUser.userType === 'primary_segregator' && (
+                <PrimarySegregatorBottomBar />
+              )}
           </React.Fragment>
         </Router>
       </React.Fragment>

--- a/frontend/src/components/PFCAdmin/NewProject.js
+++ b/frontend/src/components/PFCAdmin/NewProject.js
@@ -51,12 +51,12 @@ class NewProject extends Component {
 
   componentDidMount() {
     const vendors = this.props.vendors;
-    vendors.forEach(vendor => vendor["label"] = vendor.name);
-    const wholesalers = findVendorsByType(vendors, "wholesaler");
-    const primarySegregators = findVendorsByType(vendors, "dwcc");
+    vendors.forEach(vendor => (vendor['label'] = vendor.name));
+    const wholesalers = findVendorsByType(vendors, 'wholesaler');
+    const primarySegregators = findVendorsByType(vendors, 'primary_segregator');
     this.setState({
       wholesalerOptions: wholesalers,
-      primarySegregatorOptions: primarySegregators
+      primarySegregatorOptions: primarySegregators,
     });
   }
 

--- a/frontend/src/components/PFCAdmin/TransactionHistory.js
+++ b/frontend/src/components/PFCAdmin/TransactionHistory.js
@@ -53,7 +53,7 @@ const dummyTransactions = [
     },
     to_vendor: {
       id: 2,
-      vendor_type: 'dwcc',
+      vendor_type: 'primary_segregator',
       name: 'Stephen Curry',
       meta_data: {},
       created_at: Date.now(),

--- a/frontend/src/components/PrimarySegregator/PrimarySegregatorBuyTransaction.js
+++ b/frontend/src/components/PrimarySegregator/PrimarySegregatorBuyTransaction.js
@@ -31,7 +31,7 @@ async function onSubmit() {
 
 function getStakeholderOptions() {
   const currentVendorId = this.props.currentUser.userDetails.vendor_id;
-  // const url = `/vendors/dwcc/${currentVendorId}/wastepickers`;
+  // const url = `/vendors/primary_segregator/${currentVendorId}/wastepickers`;
   // get(url).then(res => console.log(res.data)); // This gives me an empty array always idk why
   //TODO: this always gives an empty array - figure out how to get the endpoint working
   const wastepickerIds = [3, 4];


### PR DESCRIPTION
Rename all "dwcc" to "primary_segregator", including the vendor_type and vendor_subtype enum change in db.

Test: `flask db upgrade` replaces existing dwcc entries; `flask db downgrade` also works as expected. `/vendors` and `/vendors/primary_segregator` give expected responses.

Instructions when pulling this PR: this PR modifies the vendor_type/vendor_subtype enum "dwcc" to "primary_segregator", therefore changes the database schema. To apply the latest change, simply run `flask db upgrade` after pulling the change - this will update existing "dwcc" entries automatically. If you run into any errors, please let me know! :)