### PR TITLE
Retrieve buy/sell stakeholders in transactions dynamically

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.6"

--- a/frontend/src/components/PrimarySegregator/PrimarySegregatorBuyTransaction.js
+++ b/frontend/src/components/PrimarySegregator/PrimarySegregatorBuyTransaction.js
@@ -33,23 +33,9 @@ async function onSubmit() {
   });
 }
 
-function getStakeholderOptions() {
-  const currentVendorId = this.props.currentUser.userDetails.vendor_id;
-  // const url = `/vendors/primary_segregator/${currentVendorId}/wastepickers`;
-  // get(url).then(res => console.log(res.data)); // This gives me an empty array always idk why
-  //TODO: this always gives an empty array - figure out how to get the endpoint working
-  const wastepickerIds = [3, 4];
-  const filteredVendors = this.props.vendors.filter(vendor => wastepickerIds.includes(vendor.id));
-  return filteredVendors.map(buyVendor => ({
-    label: buyVendor.name,
-    value: buyVendor.id,
-  }));
-}
-
 const members = {
   onSubmit: onSubmit,
   transactionType: transactionTypes.BUY,
-  getStakeholderOptions: getStakeholderOptions,
 };
 
 export default composeTransaction(members);

--- a/frontend/src/components/PrimarySegregator/PrimarySegregatorSellTransaction.js
+++ b/frontend/src/components/PrimarySegregator/PrimarySegregatorSellTransaction.js
@@ -32,20 +32,9 @@ async function onSubmit() {
   });
 }
 
-function getStakeholderOptions() {
-  // const currentVendorId = this.props.currentUser.userDetails.vendor_id;
-  const wastepickerIds = [1, 2];
-  const filteredVendors = this.props.vendors.filter(vendor => wastepickerIds.includes(vendor.id));
-  return filteredVendors.map(sellVendor => ({
-    label: sellVendor.name,
-    value: sellVendor.id,
-  }));
-}
-
 const members = {
   onSubmit: onSubmit,
   transactionType: transactionTypes.SELL,
-  getStakeholderOptions: getStakeholderOptions,
 };
 
 export default composeTransaction(members);

--- a/frontend/src/components/utils/vendors.js
+++ b/frontend/src/components/utils/vendors.js
@@ -2,8 +2,16 @@ export function findVendorById(vendors, id) {
   return vendors.find(vendor => id === vendor.id);
 }
 
+export function findVendorsByIds(vendors, ids) {
+  return vendors.filter(vendor => ids.includes(vendor.id));
+}
+
 export function findVendorsByType(vendors, type) {
   return vendors.filter(vendor => type === vendor.vendor_type);
+}
+
+export function findVendorsByTypes(vendors, types) {
+  return vendors.filter(vendor => types.includes(vendor.vendor_type));
 }
 
 export function removeUnderscoresAndCapitalize(str) {


### PR DESCRIPTION
Got rid of ```getStakeholderOptions()``` as buy stakeholders need to be retrieved through a get request and requires resolving a ```Promise``` while sell stakeholders can be obtained by simply filtering the ```vendors``` stored in state. Current implementation looks kind of messy though and wondering if there's a cleaner way?