### PR TITLE
Get metadata working for CreateNewWastepicker

### DIFF
--- a/backend/app/models/mixins.py
+++ b/backend/app/models/mixins.py
@@ -1,3 +1,4 @@
+import json
 from sqlalchemy import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
@@ -48,7 +49,7 @@ class BaseMixin:
         metadata_spec = METADATA_SPECS.get(cls.__tablename__, {})
         if METADATA_COLUMN in kwargs and metadata_spec is not None:
             kwargs[METADATA_COLUMN] = cls.sanitize_metadata(
-                kwargs[METADATA_COLUMN], metadata_spec)
+                json.loads(kwargs[METADATA_COLUMN]), metadata_spec)
 
         instance = cls(**kwargs)
         return instance.save()

--- a/backend/app/routes/vendor_routes.py
+++ b/backend/app/routes/vendor_routes.py
@@ -70,5 +70,5 @@ def get_wastepicker_types():
     wastepicker_types = []
     for vendor_subtype, vendor_type in vendor_subtype_map.items():
         if (vendor_type == 'wastepicker'):
-            wastepicker_types.append({'code': vendor_subtype})
+            wastepicker_types.append({'value': vendor_subtype})
     return success(data=wastepicker_types)

--- a/frontend/src/components/PFCAdmin/AdminNewStakeholder.js
+++ b/frontend/src/components/PFCAdmin/AdminNewStakeholder.js
@@ -85,7 +85,7 @@ class AdminNewStakeholder extends Component {
           <SearchSelect
             options={ProjectData}
             onChange={selectedOption => this.setState({ projectSelected: selectedOption })}
-            value={this.state.projectSelected}
+            value={this.state.selectedProjects}
             multi
             className="form-element"
           />

--- a/frontend/src/components/PrimarySegregator/CreateWastePicker.js
+++ b/frontend/src/components/PrimarySegregator/CreateWastePicker.js
@@ -61,15 +61,16 @@ class CreateWastePicker extends Component {
     const data = [];
     Object.keys(fieldsInfo).forEach(field => {
       if (!this.state[field]) return;
-      if (fieldsInfo[field].type === 'metaData') metaData[snakeCase(field)] = this.state[field];
+      const fieldValue = this.state[field].value ? this.state[field].value : this.state[field];
+      if (fieldsInfo[field].type === 'metaData') metaData[snakeCase(field)] = fieldValue;
       else {
         data.push({
           key: snakeCase(field),
-          value: this.state[field],
+          value: fieldValue,
         });
       }
     });
-    // data.push({ key: 'meta_data', value: metaData });
+    data.push({ key: 'meta_data', value: metaData });
     return postMultiType('/vendors', {
       data: data,
       authToken: this.props.cookies.get('access_token'),
@@ -79,12 +80,12 @@ class CreateWastePicker extends Component {
   async componentDidMount() {
     const wastepickerTypes = await get('/vendors/wastepicker_types');
     wastepickerTypes.data.forEach(function(option) {
-      if (option.code === 'wastepicker') {
+      if (option.value === 'wastepicker') {
         option['label'] = 'Waste Picker (General)';
-      } else if (option.code === 'wp_community_leader') {
+      } else if (option.value === 'wp_community_leader') {
         option['label'] = 'Waste Picker Community Leader';
       } else {
-        option['label'] = removeUnderscoresAndCapitalize(option.code);
+        option['label'] = removeUnderscoresAndCapitalize(option.value);
       }
     });
     this.setState({

--- a/frontend/src/components/utils/requests.js
+++ b/frontend/src/components/utils/requests.js
@@ -30,7 +30,11 @@ export function postMultiType(path, payload) {
   const url = process.env.REACT_APP_API_URL + path;
   const formData = new FormData();
   payload.data.forEach(field => {
-    formData.append(field.key, field.value);
+    if (field.key === 'meta_data') {
+      formData.append(field.key, JSON.stringify(field.value));
+    } else {
+      formData.append(field.key, field.value);
+    }
   });
   const data = {
     method: 'POST',


### PR DESCRIPTION
In order to send a metadata object in FormData, we have to convert the object to a string then parse it back into json on the server-side. If we send a pure object into FormData, it's sent to the backend as a literal string "[Object object]".

Also, fixed the dropdown selection on forms (the value of the dropdown is set to an object, rather than a value - so when pulling the value of a dropdown, we have to call `selectedValue.value` when building the post request). As such, I edited /vendors/wastepickerTypes to return "value" instead of "code" so the "value" field can be our key when getting dropdown options.