### PR TITLE
Added auth_token table for blacklisting

### DIFF
--- a/backend/app/models/blacklisted_auth_token.py
+++ b/backend/app/models/blacklisted_auth_token.py
@@ -1,0 +1,6 @@
+from . import db
+from .mixins import BaseMixin
+
+class BlacklistedAuthToken(BaseMixin, db.Model):
+    __tablename__ = 'blacklisted_auth_token'
+    token = db.Column(db.String(2047), nullable=False, primary_key=True)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,12 +1,10 @@
 import os
 import boto3
-from flask_jwt_extended import JWTManager
-
-jwt = JWTManager()
+from . import jwt_manager
 
 
 def init_app(app):
-    jwt.init_app(app)
+    jwt_manager.jwt.init_app(app)
 
     from .utils.converters import ListConverter
 
@@ -23,6 +21,9 @@ def init_app(app):
     CORS(project_routes.blueprint)
     CORS(user_routes.blueprint)
     CORS(vendor_routes.blueprint)
+
+    app.config['JWT_BLACKLIST_ENABLED'] = True
+    app.config['JWT_BLACKLIST_TOKEN_CHECKS'] = ['access']
 
     app.register_blueprint(auth_routes.blueprint)
     app.register_blueprint(project_routes.blueprint)

--- a/backend/app/routes/auth_routes.py
+++ b/backend/app/routes/auth_routes.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from flask import Blueprint, request
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import create_access_token, get_raw_jwt, jwt_required
 
 from . import db_client
 from .utils.route_utils import error_response, success
@@ -19,9 +19,22 @@ def login():
     if not user:
         return error_response(message="The email or password is incorrect.")
 
+    # TODO(joyce): add access_token length check. Right now db column is restricted
+    # to 2047 characters max.
     access_token = _create_access_token(user)
 
     return success(access_token=access_token, data=user.to_dict())
+
+
+# Endpoint for revoking the current users access token
+@blueprint.route('/logout', methods=['DELETE'])
+@jwt_required
+def logout():
+    jti = get_raw_jwt()['jti']
+    new_blacklist_token = db_client.add_auth_token_to_blacklist({"token": jti})
+    if new_blacklist_token is None:
+        return error_response(message="Unable to blacklist token upon logout.")
+    return success()
 
 
 def _authenticate_user(email, password):

--- a/backend/app/routes/db_client.py
+++ b/backend/app/routes/db_client.py
@@ -1,11 +1,19 @@
 from sqlalchemy import or_
 
-from . import s3_client
+from ..models.blacklisted_auth_token import BlacklistedAuthToken
 from ..models.project import Project
 from ..models.transaction import Transaction
 from ..models.user import User
 from ..models.vendor import PrimarySegregatorWastepickerMap, Vendor
 
+
+def add_auth_token_to_blacklist(data):
+    blacklisted_auth_token = BlacklistedAuthToken.create(**data)
+    return blacklisted_auth_token
+
+
+def get_blacklisted_auth_token(token):
+    return BlacklistedAuthToken.get_by(first=True, token=token)
 
 # TODO(imran): write decorator to make db reads/writes atomic
 def create_project(data):
@@ -43,6 +51,7 @@ def get_user(email):
 
 
 def create_vendor(data, current_user=None, files=None):
+    from . import s3_client
     if files is not None and 'picture' in files:
         image_link = s3_client.upload_user_image(files['picture'])
         data['image_link'] = image_link

--- a/backend/app/routes/jwt_manager.py
+++ b/backend/app/routes/jwt_manager.py
@@ -1,0 +1,13 @@
+from flask_jwt_extended import JWTManager
+from .db_client import get_blacklisted_auth_token
+
+jwt = JWTManager()
+
+
+# Define the callback function for the @jwt.token_in_blacklist_loader decorator. If
+# app.config['JWT_BLACKLIST_ENABLED'] is set, this will be invoked every time @jwt_required is added
+# to an endpoint.
+@jwt.token_in_blacklist_loader
+def check_if_token_in_blacklist(decrypted_token):
+    jti = decrypted_token['jti']
+    return get_blacklisted_auth_token(jti) is not None

--- a/backend/migrations/versions/bb9dcde5ba02_add_blacklisted_auth_token_table.py
+++ b/backend/migrations/versions/bb9dcde5ba02_add_blacklisted_auth_token_table.py
@@ -1,0 +1,27 @@
+"""add blacklisted_auth_token table
+
+Revision ID: bb9dcde5ba02
+Revises: 1f2ce093b5aa
+Create Date: 2019-01-21 20:17:35.659360
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bb9dcde5ba02'
+down_revision = '1f2ce093b5aa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('blacklisted_auth_token',
+    sa.Column('token', sa.String(length=2047), nullable=False),
+    sa.PrimaryKeyConstraint('token')
+    )
+
+
+def downgrade():
+    op.drop_table('blacklisted_auth_token')


### PR DESCRIPTION
Change:
* Added auth_token in models and db_client, with the primary key being the token string
* Added logout in auth_routes which creates a blacklisted entry in the auth_token table upon user logout
* Extracted the jwt manager initialization from __init__ to a jwt_manager utils file, which also implements the callback for the jwt token_in_blacklist_loader decorator, which checks if the given token is in the db already

TODO:
* There's no length limit on the token string (but anything > 8 KB will break the HTTP request though). In the db the column length is hardcoded to be 2047 max, but in the code currently there's no checking whatsoever -- smells like a potential buffer overflow here...

Test:
* Tested on postman by initiating a login request, using the access token to access the vendors page etc., logout, and then try access the vendors page with the same token again (this time got a "revoked token" error message)
* `flask db upgrade` works, and blacklisted entries are being added to the db

Instructions when pull:
* `flask db upgrade` as usual