### PR TITLE
Enable frontend logout to invoke backend logout endpoint

### DIFF
--- a/frontend/src/components/common/LogoutButton.js
+++ b/frontend/src/components/common/LogoutButton.js
@@ -1,8 +1,15 @@
 import React, { Component } from 'react';
+import { delete_request } from '../utils/requests';
 import './LogoutButton.css';
 
 class LogoutButton extends Component {
-  logout() {
+  async logout() {
+    try {
+      await delete_request('/auth/logout', this.props.cookies.get('access_token'));
+    } catch (err) {
+      console.error(err);
+      alert('Unable to logout.');
+    }
     // delete the access_token cookie
     this.props.cookies.remove('access_token');
     // redirect to login screen

--- a/frontend/src/components/utils/requests.js
+++ b/frontend/src/components/utils/requests.js
@@ -71,3 +71,23 @@ export function get(path, authToken) {
       throw err;
     });
 }
+
+export function delete_request(path, authToken) {
+  const url = process.env.REACT_APP_API_URL + path;
+  const data = {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthorizationHeader(authToken),
+    },
+  };
+  return fetch(url, data)
+    .then(response => {
+      if (response.ok) return response.json();
+      throw response;
+    })
+    .catch(err => {
+      console.error(err);
+      throw err;
+    });
+}


### PR DESCRIPTION
Added the async delete request to the backend logout endpoint :)

Highlights:
- Added a wrapper in frontend utils for DELETE requests (delete is a keyword in js; thus delete_request)
- Made the logout function async to await delete_request

Not sure about:
- Should we add another check to see the HTTP status is ok?

Test:
- Hitting the logout button sends the request on the backend and adds new entries in the blacklisted_auth_token table ✌️ 