### PR TITLE
Made transactions to_acknowledged column nullable

### DIFF
--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -11,7 +11,7 @@ class Transaction(BaseMixin, db.Model):
         db.Integer, db.ForeignKey('vendor.id'), nullable=False)
     to_vendor_id = db.Column(
         db.Integer, db.ForeignKey('vendor.id'), nullable=False)
-    to_acknowledged = db.Column(db.Boolean, nullable=False, default=False)
+    to_acknowledged = db.Column(db.Boolean, nullable=True, default=False)
     acknowledged_at = db.Column(db.DateTime)
     price = db.Column(db.Float(2), nullable=False)
     sale_date = db.Column(db.DateTime, nullable=False, default=db.func.now())

--- a/backend/migrations/versions/c52d0ca1f9bf_make_to_acknowledged_nullable.py
+++ b/backend/migrations/versions/c52d0ca1f9bf_make_to_acknowledged_nullable.py
@@ -1,0 +1,41 @@
+"""make to_acknowledged nullable
+
+Revision ID: c52d0ca1f9bf
+Revises: bb9dcde5ba02
+Create Date: 2019-01-31 19:25:51.587384
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c52d0ca1f9bf'
+down_revision = 'bb9dcde5ba02'
+branch_labels = None
+depends_on = None
+
+transaction_to_acknowledged_new_tcr = sa.sql.table(
+    'transaction', sa.Column('to_acknowledged', sa.BOOLEAN(), nullable=True))
+
+
+def upgrade():
+    op.alter_column('transaction', 'to_acknowledged',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    # Change all existing entries to Null.
+    op.execute(
+        transaction_to_acknowledged_new_tcr.update()
+            .where(transaction_to_acknowledged_new_tcr.c.to_acknowledged is not None)
+            .values(to_acknowledged=None))
+
+
+def downgrade():
+    # Change all Null entries to True.
+    op.execute(
+        transaction_to_acknowledged_new_tcr.update()
+            .where(transaction_to_acknowledged_new_tcr.c.to_acknowledged == None)
+            .values(to_acknowledged=True))
+    op.alter_column('transaction', 'to_acknowledged',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)


### PR DESCRIPTION
Made the to_acknowledged column nullable, so that NULL means the wholesaler hasn't seen it; true means acknowledged and false means reject. Previously there's no way to represent transactions as "acknowledged" but rejected.

Highlights:
* Turned on "nullable" in the db schema
* Set all existing db entries to Null in the db migration file
* Added backward compatibility by changing all null entries to True when downgrading the schema

Tests:
* Both `flask db upgrade` and `flask db downgrade` work; also tested on existing db entries

Instructions when pull:
* `flask db upgrade`