### PR TITLE
Fix circular dependency

### DIFF
--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,20 +1,17 @@
 import os
 import boto3
-from . import jwt_manager
-
 
 def init_app(app):
+    from . import jwt_manager
     jwt_manager.jwt.init_app(app)
 
     from .utils.converters import ListConverter
-
     app.url_map.converters['list'] = ListConverter
 
     from . import auth_routes
     from . import project_routes
     from . import user_routes
     from . import vendor_routes
-
     from flask_cors import CORS
 
     CORS(auth_routes.blueprint)


### PR DESCRIPTION
Move `import jwt_manager` into `init_app` body so we have less possibility of circular dependency

I realized that most of the custom imports in `__init__` happen in `init_app()`, probably to avoid the circular dependency problem we found earlier. Since we can't really move `s3_resource` out of `__init__`, I moved the line `from . import jwt_manager` into the function body of `init_app()`, so if any module imports from `__init__` in the future it won't run into a circular dependency.