### PR TITLE
Missing Vendor Alert Popup

### DIFF
--- a/frontend/src/components/PrimarySegregator/PSTransactionHistory.js
+++ b/frontend/src/components/PrimarySegregator/PSTransactionHistory.js
@@ -98,7 +98,7 @@ class PSTransactionHistory extends Component {
           alert(
             `Missing vendor from buy transactions table with vendor id ${
               transaction.from_vendor_id
-            }`
+            }. Please try refreshing.`
           );
           return;
         }
@@ -110,7 +110,9 @@ class PSTransactionHistory extends Component {
         if (!vendor) {
           logMissingVendor(this.props.vendors, transaction.to_vendor_id);
           alert(
-            `Missing vendor from sell transactions table with vendor id ${transaction.to_vendor_id}`
+            `Missing vendor from sell transactions table with vendor id ${
+              transaction.to_vendor_id
+            }. Please try refreshing.`
           );
           return;
         }


### PR DESCRIPTION
The linter we are using is changing the "missing buy vendor" alert popup to have that nested format but not the "missing sell vendor" alert popup. Not sure why, nor am I able to change that without doing some linter bypass thing which I don't think is necessary at this moment.