### PR TITLE
Fix discrepancies in user ID and vendor ID

### DIFF
--- a/frontend/src/components/PrimarySegregator/CreatePSTransactionContainer.js
+++ b/frontend/src/components/PrimarySegregator/CreatePSTransactionContainer.js
@@ -68,7 +68,7 @@ class CreatePSTransactionContainer extends Component {
 
   async refreshStakeholderOptions() {
     const transactionType = this.props.match.params.transactionType;
-    const currentVendorId = this.props.currentUser.userDetails.id;
+    const currentVendorId = this.props.currentUser.userDetails.vendor_id;
 
     // SELL trans
     let vendors = findVendorsByTypes(this.props.vendors, ['wholesaler', 'primary_segregator']);
@@ -115,6 +115,7 @@ class CreatePSTransactionContainer extends Component {
     }
 
     const transactionType = this.props.match.params.transactionType;
+    const currentUserId = this.props.currentUser.userDetails.id; // User ID and vendor ID are distinct
     const currentVendorId = this.props.currentUser.userDetails.vendor_id;
     const totalPrice = this.state.unitPrice * this.state.weight;
     const stakeholderName = this.state.stakeholderName;
@@ -150,7 +151,7 @@ class CreatePSTransactionContainer extends Component {
       },
       {
         key: 'creator_id',
-        value: currentVendorId,
+        value: currentUserId,
       },
       {
         key: 'sale_date',


### PR DESCRIPTION
- Each vendor has 2 IDs associated with them: a user ID (users can be admins, wholesalers, primary segregators, etc), and a vendor ID (vendors are wastepickers, PSs, wholesalers, etc - parties in the plastics chain)
- When pulling a list of wastepickers/PSs that are associated with a primary segregator, we use the *vendor ID*
- When making a transaction, the field for `toVendorId` and `fromVendorId` should be filled with the vendor ID. On the other hand, the field for `creatorId` should be filled with the user ID.