### PR TITLE
Fix package lock and import problems in frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^3.9.2",
     "classnames": "^2.2.6",
     "husky": "^0.14.3",
     "immutable": "^3.8.2",

--- a/frontend/src/components/input-components/IconTextInput.js
+++ b/frontend/src/components/input-components/IconTextInput.js
@@ -7,8 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import IconButton from '@material-ui/core/IconButton';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
-import { AttachMoney, ShoppingBasket, Autorenew } from '@material-ui/icons';
-import Grid from '@material-ui/core/Grid';
+import { Grid } from '@material-ui/core/Grid';
 import Rupee from '../../assets/Rupee';
 
 const styles = {


### PR DESCRIPTION
- Material UI was included in the `package-lock.json`
- Unused Material UI icons were removed