### PR TITLE
Create new entry in the podio sourcing table for each sell transaction

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.6"

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -38,28 +38,4 @@ def create_s3_resource():
     )
 
 
-def create_podio_sourcing_client():
-    from .podio_client import api
-    return api.OAuthAppClient(
-        os.environ['PODIO_CLIENT_NAME'],
-        os.environ['PODIO_CLIENT_SECRET'],
-        os.environ['PODIO_SOURCING_APP_ID'],
-        os.environ['PODIO_SOURCING_APP_TOKEN']
-    )
-
-
-def create_podio_stakeholders_client():
-    from .podio_client import api
-    return api.OAuthAppClient(
-        os.environ['PODIO_CLIENT_NAME'],
-        os.environ['PODIO_CLIENT_SECRET'],
-        os.environ['PODIO_STAKEHOLDERS_APP_ID'],
-        os.environ['PODIO_STAKEHOLDERS_APP_TOKEN']
-    )
-
-
 s3_resource = create_s3_resource()
-
-# Create podio clients
-# sourcing_podio_client = create_podio_sourcing_client()
-# stakesholders_podio_client = create_podio_stakeholders_client()

--- a/backend/app/routes/podio_client/__init__.py
+++ b/backend/app/routes/podio_client/__init__.py
@@ -1,3 +1,2 @@
 """ Podio client api in Python 3
-    Mostly following the official pypodio2 at https://github.com/podio/podio-py
-"""
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""

--- a/backend/app/routes/podio_client/api.py
+++ b/backend/app/routes/podio_client/api.py
@@ -1,3 +1,6 @@
+""" Podio client api in Python 3
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""
+
 from . import transport, client
 
 

--- a/backend/app/routes/podio_client/areas.py
+++ b/backend/app/routes/podio_client/areas.py
@@ -1,3 +1,6 @@
+""" Podio client api in Python 3
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""
+
 import json
 
 try:

--- a/backend/app/routes/podio_client/client.py
+++ b/backend/app/routes/podio_client/client.py
@@ -1,3 +1,6 @@
+""" Podio client api in Python 3
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""
+
 from . import areas
 
 

--- a/backend/app/routes/podio_client/encode.py
+++ b/backend/app/routes/podio_client/encode.py
@@ -1,3 +1,6 @@
+""" Podio client api in Python 3
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""
+
 """multipart/form-data encoding module
 
 This module provides functions that faciliate encoding name/value pairs

--- a/backend/app/routes/podio_client/transport.py
+++ b/backend/app/routes/podio_client/transport.py
@@ -1,3 +1,6 @@
+""" Podio client api in Python 3
+    Adapted from the official pypodio2 at https://github.com/podio/podio-py"""
+
 from httplib2 import Http
 
 try:

--- a/backend/app/routes/podio_utils.py
+++ b/backend/app/routes/podio_utils.py
@@ -1,0 +1,55 @@
+import os
+from .podio_client import api
+from .podio_client.transport import TransportException
+
+
+def create_podio_sourcing_client():
+    return api.OAuthAppClient(
+        os.environ['PODIO_CLIENT_NAME'],
+        os.environ['PODIO_CLIENT_SECRET'],
+        os.environ['PODIO_SOURCING_APP_ID'],
+        os.environ['PODIO_SOURCING_APP_TOKEN']
+    )
+
+
+def create_podio_stakeholders_client():
+    return api.OAuthAppClient(
+        os.environ['PODIO_CLIENT_NAME'],
+        os.environ['PODIO_CLIENT_SECRET'],
+        os.environ['PODIO_STAKEHOLDERS_APP_ID'],
+        os.environ['PODIO_STAKEHOLDERS_APP_TOKEN']
+    )
+
+
+# create a new entry in the podio sourcing table when a ps sell transaction happens
+# parameter: transaction (type: Transaction in models/transaction.py)
+def create_sourcing_item(transaction_data):
+    # TODO(joyce): right now podio_purchase_from_id, project_id and material_type_category are all
+    # hardcoded. There should be a mapping between the vendor id in this app and the item id
+    # in the stakeholders/project apps and the plastic category enum in the podio app.
+    podio_purchase_from_id = 1045698435  # should make use of transaction_data["from_vendor_id"]
+    date_purchased = transaction_data["sale_date"] + " 00:00:00"
+    podio_sourcing_project_id = 1045701763
+    try:
+        client = create_podio_sourcing_client()
+    except TransportException as e:
+        print("Failed to establish Podio sourcing client:")
+        print(e)
+        return
+    for plastic in transaction_data["plastics"]:
+        purchase_price_rs = plastic["price"]
+        quantity_kg = plastic["quantity"]
+        podio_material_type_category = 1  # should make use of plastic["plastic_type"]
+        item = {
+            'fields':
+                [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
+                 {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
+                 {'external_id': 'material-type', 'values': [{'value': podio_material_type_category}]},
+                 {'external_id': 'purchase-price-rs', 'values': [{'value': purchase_price_rs}]},
+                 {'external_id': 'quantity-kg', 'values': [{'value': quantity_kg}]},
+                 {'external_id': 'sourcing-for-po', 'values': [{'value': podio_sourcing_project_id}]}]}
+        try:
+            client.Item.create(int(os.environ['PODIO_SOURCING_APP_ID']), item)
+        except TransportException as e:
+            print("Failed to create Podio sourcing entry:")
+            print(e)  # logerror

--- a/backend/app/routes/vendor_routes.py
+++ b/backend/app/routes/vendor_routes.py
@@ -3,6 +3,7 @@ from flask_jwt_extended import get_jwt_identity, jwt_required
 import json
 
 from . import db_client
+from . import podio_utils
 from .utils.route_utils import success
 from ..models.vendor import vendor_subtype_map
 from flask_cors import cross_origin
@@ -40,6 +41,13 @@ def create_vendor_transaction(vendor_id):
     transaction_data = request.json if is_application_json else request.form.to_dict()
     if not is_application_json and 'plastics' in transaction_data:
         transaction_data['plastics'] = json.loads(transaction_data['plastics'])
+
+    # podio integration
+    if vendor_id == int(transaction_data["from_vendor_id"]):
+        # sell transaction
+        podio_utils.create_sourcing_item(transaction_data)
+
+    # create transaction in db
     transaction = db_client.create_transaction(transaction_data, request.files)
     return success(data=transaction.to_dict(include_relationships=True))
 


### PR DESCRIPTION
Add a new entry to the podio sourcing table whenever a sell transaction happens.

Hightlights:
* Differentiate between buy and sell transactions in vendor_routes.py to only invoke insertion in podio sourcing during sell transactions
* Refactors podio helpers from __init__.py into podio_utils.py
* Added new helper in podio_utils.py for creating a new entry in the sourcing table

Testing:
* It worked! (new entry in podio sourcing is created)