### PR TITLE
Create a new row in podio buy transaction table for each buy transaction

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -12,3 +12,5 @@ PODIO_SOURCING_APP_ID=ask-joyce-for-this
 PODIO_SOURCING_APP_TOKEN=ask-joyce-for-this
 PODIO_STAKEHOLDERS_APP_ID=ask-joyce-for-this
 PODIO_STAKEHOLDERS_APP_TOKEN=ask-joyce-for-this
+PODIO_PS_BUY_APP_ID=ask-joyce-for-this
+PODIO_PS_BUY_APP_TOKEN=ask-joyce-for-this

--- a/backend/app/routes/podio_utils.py
+++ b/backend/app/routes/podio_utils.py
@@ -21,6 +21,15 @@ def create_podio_stakeholders_client():
     )
 
 
+def create_podio_buy_transaction_client():
+    return api.OAuthAppClient(
+        os.environ['PODIO_CLIENT_NAME'],
+        os.environ['PODIO_CLIENT_SECRET'],
+        os.environ['PODIO_PS_BUY_APP_ID'],
+        os.environ['PODIO_PS_BUY_APP_TOKEN']
+    )
+
+
 # create a new entry in the podio sourcing table when a ps sell transaction happens
 # parameter: transaction (type: Transaction in models/transaction.py)
 def create_sourcing_item(transaction_data):
@@ -29,7 +38,7 @@ def create_sourcing_item(transaction_data):
     # in the stakeholders/project apps and the plastic category enum in the podio app.
     podio_purchase_from_id = 1045698435  # should make use of transaction_data["from_vendor_id"]
     date_purchased = transaction_data["sale_date"] + " 00:00:00"
-    podio_sourcing_project_id = 1045701763
+    podio_sourcing_project_id = 1045701763  # should make use of transaction_data["project_id"]
     try:
         client = create_podio_sourcing_client()
     except TransportException as e:
@@ -85,3 +94,40 @@ def get_visible_wholesalers(item_id):
             }
             matches.append(data)
     return matches
+
+
+# create a new entry in the buy transaction table when a ps buy transaction happens
+# parameter: transaction (type: Transaction in models/transaction.py)
+def create_buy_transaction_item(transaction_data):
+    # TODO(joyce): right now podio_purchase_from_id, project_id and material_type_category are all
+    # hardcoded. There should be a mapping between the vendor id in this app and the item id
+    # in the stakeholders/project apps, the plastic category enum and plastic type item id in the
+    # podio plastic type app (master), the project id and the item id in the podio pfc projects app.
+    podio_purchase_from_id = 1079205608  # should make use of transaction_data["from_vendor_id"]
+    podio_purchase_by_id = 1073122201  # should make use of transaction_data["to_vendor_id"]
+    date_purchased = transaction_data["sale_date"] + " 00:00:00"
+    podio_buy_project_id = 1075917335  # should make use of transaction_data["project_id"]
+    try:
+        client = create_podio_buy_transaction_client()
+    except TransportException as e:
+        print("Failed to establish Podio sourcing client:")
+        print(e)
+        return
+    for plastic in transaction_data["plastics"]:
+        purchase_price_rs = plastic["price"]
+        quantity_kg = plastic["quantity"]
+        podio_plastic_type = 1057427095  # should make use of plastic["plastic_type"]
+        item = {
+            'fields':
+                [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
+                 {'external_id': 'purchased-by', 'values': [{'value': podio_purchase_by_id}]},
+                 {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
+                 {'external_id': 'price-rs', 'values': [{'value': purchase_price_rs}]},
+                 {'external_id': 'quantity', 'values': [{'value': quantity_kg}]},
+                 {'external_id': 'plastic-type-2', 'values': [{'value': podio_plastic_type}]},
+                 {'external_id': 'pfc-project-3', 'values': [{'value': podio_buy_project_id}]}]}
+        try:
+            client.Item.create(int(os.environ['PODIO_PS_BUY_APP_ID']), item)
+        except TransportException as e:
+            print("Failed to create Podio buy transaction entry:")
+            print(e)  # logerror

--- a/backend/app/routes/vendor_routes.py
+++ b/backend/app/routes/vendor_routes.py
@@ -48,6 +48,9 @@ def create_vendor_transaction(vendor_id):
     if vendor_id == int(transaction_data["from_vendor_id"]):
         # sell transaction
         podio_utils.create_sourcing_item(transaction_data)
+    else:
+        # buy transaction
+        podio_utils.create_buy_transaction_item(transaction_data)
 
     # create transaction in db
     transaction = db_client.create_transaction(transaction_data, request.files)


### PR DESCRIPTION
Insert a new row into the podio master buy transaction table for each buy transaction in our app.

Highlights:
* Create a new helper in podio_utils.py that makes a call to podio to create a new item

TODO:
Like the earlier PR on creating new entries in the sourcing table, this PR hardcodes podio item ids. Next step would be to create mappings between our stakeholder ids and podio stakeholder ids (also applies to plastic types and project ids).