### PR TITLE
Fix timezone bug in transaction history

### DIFF
--- a/frontend/src/components/PrimarySegregator/CreatePSTransactionContainer.js
+++ b/frontend/src/components/PrimarySegregator/CreatePSTransactionContainer.js
@@ -120,6 +120,7 @@ class CreatePSTransactionContainer extends Component {
     let toVendor =
       transactionType === TRANSACTION_TYPES.BUY ? currentVendorId : stakeholderName.value;
     const receiptPicture = this.state.receiptPicture;
+    const utcTimeOffset = new Date().getTimezoneOffset();
 
     const data = [
       {
@@ -150,7 +151,9 @@ class CreatePSTransactionContainer extends Component {
       },
       {
         key: 'sale_date',
-        value: saleDate !== '' ? saleDate : moment(Date.now()).format('YYYY-MM-DD'),
+        value: moment(saleDate)
+        .add(utcTimeOffset, 'minutes')
+        .format('YYYY-MM-DD HH:mm:ss'),
       },
     ];
 


### PR DESCRIPTION
The issue with timezone is that even though transaction dates are created in the local timezone, the timezone isn't stored in the backend, so when dates are returned to the frontend in transaction history, they are interpreted as UTC and calling ```.local()``` creates an offset.

Removing the ```.local()``` would solve the issue, but only if we assume transactions are always created and viewed in the same timezone. Not sure if this will always be the case, so this is a more robust solution of adding the UTC offset to dates before sending them to the backend and keeping the conversion to local time in the frontend.