### PR TITLE
Add plastic type mapping from our enums to podio item id

### DIFF
--- a/backend/app/routes/podio_utils.py
+++ b/backend/app/routes/podio_utils.py
@@ -3,6 +3,23 @@ from .podio_client import api
 from .podio_client.transport import TransportException
 
 
+# map our plastic type to the plastic type item id in the podio master plastic type table.
+ps_buy_plastic_type_map = {
+    'clear_pet': 1057427095,
+    'mixed_pet': 1081865225,
+    'pugga': 1081865273,
+    'kadak': 1081866049,
+    'mixed_plastic_waste': 1081865127,
+    'films': 1081866090
+}
+
+# map our plastic type to the plastic type enum defined in the podio sourcing table schema.
+ps_sell_plastic_type_map = {
+    'mixed_pet': 1,
+    'pugga': 2
+}
+
+
 def create_podio_sourcing_client():
     return api.OAuthAppClient(
         os.environ['PODIO_CLIENT_NAME'],
@@ -37,7 +54,7 @@ def create_sourcing_item(transaction_data):
     # hardcoded. There should be a mapping between the vendor id in this app and the item id
     # in the stakeholders/project apps and the plastic category enum in the podio app.
     podio_purchase_from_id = 1045698435  # should make use of transaction_data["from_vendor_id"]
-    date_purchased = transaction_data["sale_date"] + " 00:00:00"
+    date_purchased = transaction_data["sale_date"]
     podio_sourcing_project_id = 1045701763  # should make use of transaction_data["project_id"]
     try:
         client = create_podio_sourcing_client()
@@ -48,20 +65,65 @@ def create_sourcing_item(transaction_data):
     for plastic in transaction_data["plastics"]:
         purchase_price_rs = plastic["price"]
         quantity_kg = plastic["quantity"]
-        podio_material_type_category = 1  # should make use of plastic["plastic_type"]
-        item = {
-            'fields':
-                [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
-                 {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
-                 {'external_id': 'material-type', 'values': [{'value': podio_material_type_category}]},
-                 {'external_id': 'purchase-price-rs', 'values': [{'value': purchase_price_rs}]},
-                 {'external_id': 'quantity-kg', 'values': [{'value': quantity_kg}]},
-                 {'external_id': 'sourcing-for-po', 'values': [{'value': podio_sourcing_project_id}]}]}
-        try:
-            client.Item.create(int(os.environ['PODIO_SOURCING_APP_ID']), item)
-        except TransportException as e:
-            print("Failed to create Podio sourcing entry:")
-            print(e)  # logerror
+        plastic_type = plastic["plastic_type"]
+        if not plastic_type in ps_sell_plastic_type_map:
+            print("ERROR: Podio sourcing table does not support plastic type {}".format(plastic_type))
+        else:
+            podio_material_type_category = ps_sell_plastic_type_map[plastic_type]
+            item = {
+                'fields':
+                    [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
+                     {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
+                     {'external_id': 'material-type', 'values': [{'value': podio_material_type_category}]},
+                     {'external_id': 'purchase-price-rs', 'values': [{'value': purchase_price_rs}]},
+                     {'external_id': 'quantity-kg', 'values': [{'value': quantity_kg}]},
+                     {'external_id': 'sourcing-for-po', 'values': [{'value': podio_sourcing_project_id}]}]}
+            try:
+                client.Item.create(int(os.environ['PODIO_SOURCING_APP_ID']), item)
+            except TransportException as e:
+                print("Failed to create Podio sourcing entry:")
+                print(e)  # logerror
+
+
+# create a new entry in the buy transaction table when a ps buy transaction happens
+# parameter: transaction (type: Transaction in models/transaction.py)
+def create_buy_transaction_item(transaction_data):
+    # TODO(joyce): right now podio_purchase_from_id, project_id and material_type_category are all
+    # hardcoded. There should be a mapping between the vendor id in this app and the item id
+    # in the stakeholders/project apps, the plastic category enum and plastic type item id in the
+    # podio plastic type app (master), the project id and the item id in the podio pfc projects app.
+    podio_purchase_from_id = 1079205608  # should make use of transaction_data["from_vendor_id"]
+    podio_purchase_by_id = 1073122201  # should make use of transaction_data["to_vendor_id"]
+    date_purchased = transaction_data["sale_date"]
+    podio_buy_project_id = 1075917335  # should make use of transaction_data["project_id"]
+    try:
+        client = create_podio_buy_transaction_client()
+    except TransportException as e:
+        print("Failed to establish Podio sourcing client:")
+        print(e)
+        return
+    for plastic in transaction_data["plastics"]:
+        purchase_price_rs = plastic["price"]
+        quantity_kg = plastic["quantity"]
+        plastic_type = plastic["plastic_type"]
+        if not plastic_type in ps_buy_plastic_type_map:
+            print("ERROR: Podio buy transaction table does not support plastic type {}".format(plastic_type))
+        else:
+            podio_plastic_type = ps_buy_plastic_type_map[plastic_type]
+            item = {
+                'fields':
+                    [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
+                     {'external_id': 'purchased-by', 'values': [{'value': podio_purchase_by_id}]},
+                     {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
+                     {'external_id': 'price-rs', 'values': [{'value': purchase_price_rs}]},
+                     {'external_id': 'quantity', 'values': [{'value': quantity_kg}]},
+                     {'external_id': 'plastic-type-2', 'values': [{'value': podio_plastic_type}]},
+                     {'external_id': 'pfc-project-3', 'values': [{'value': podio_buy_project_id}]}]}
+            try:
+                client.Item.create(int(os.environ['PODIO_PS_BUY_APP_ID']), item)
+            except TransportException as e:
+                print("Failed to create Podio buy transaction entry:")
+                print(e)  # logerror
 
 
 def get_visible_wholesalers(item_id):
@@ -94,40 +156,3 @@ def get_visible_wholesalers(item_id):
             }
             matches.append(data)
     return matches
-
-
-# create a new entry in the buy transaction table when a ps buy transaction happens
-# parameter: transaction (type: Transaction in models/transaction.py)
-def create_buy_transaction_item(transaction_data):
-    # TODO(joyce): right now podio_purchase_from_id, project_id and material_type_category are all
-    # hardcoded. There should be a mapping between the vendor id in this app and the item id
-    # in the stakeholders/project apps, the plastic category enum and plastic type item id in the
-    # podio plastic type app (master), the project id and the item id in the podio pfc projects app.
-    podio_purchase_from_id = 1079205608  # should make use of transaction_data["from_vendor_id"]
-    podio_purchase_by_id = 1073122201  # should make use of transaction_data["to_vendor_id"]
-    date_purchased = transaction_data["sale_date"] + " 00:00:00"
-    podio_buy_project_id = 1075917335  # should make use of transaction_data["project_id"]
-    try:
-        client = create_podio_buy_transaction_client()
-    except TransportException as e:
-        print("Failed to establish Podio sourcing client:")
-        print(e)
-        return
-    for plastic in transaction_data["plastics"]:
-        purchase_price_rs = plastic["price"]
-        quantity_kg = plastic["quantity"]
-        podio_plastic_type = 1057427095  # should make use of plastic["plastic_type"]
-        item = {
-            'fields':
-                [{'external_id': 'purchased-from', 'values': [{'value': podio_purchase_from_id}]},
-                 {'external_id': 'purchased-by', 'values': [{'value': podio_purchase_by_id}]},
-                 {'external_id': 'date-purchased', 'values': [{'start': date_purchased}]},
-                 {'external_id': 'price-rs', 'values': [{'value': purchase_price_rs}]},
-                 {'external_id': 'quantity', 'values': [{'value': quantity_kg}]},
-                 {'external_id': 'plastic-type-2', 'values': [{'value': podio_plastic_type}]},
-                 {'external_id': 'pfc-project-3', 'values': [{'value': podio_buy_project_id}]}]}
-        try:
-            client.Item.create(int(os.environ['PODIO_PS_BUY_APP_ID']), item)
-        except TransportException as e:
-            print("Failed to create Podio buy transaction entry:")
-            print(e)  # logerror

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -737,6 +737,30 @@
         "regexpu-core": "^4.1.3"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.0.tgz",
+      "integrity": "sha512-bVsjsrtsDflIHp5I6caaAa2V25Kzn50HKPL6g3X0P0ni1ks+58cPB8Mz6AOKVuRPgaVdq/OwEUc/1vKqX+Mo4A==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "dev": true
+        }
+      }
+    },
     "@babel/preset-env": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
@@ -1119,7 +1143,7 @@
     },
     "@types/object-assign": {
       "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "resolved": "http://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
       "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI="
     },
     "@types/prop-types": {
@@ -4392,6 +4416,23 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz",
+      "integrity": "sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^5.0.1"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+          "dev": true
+        }
+      }
+    },
     "eslint-config-react-app": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-3.0.8.tgz",
@@ -4611,6 +4652,24 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+      "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
+      },
+      "dependencies": {
+        "jest-docblock": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.12.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
@@ -4643,6 +4702,53 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+    },
+    "eslint-watch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-watch/-/eslint-watch-4.0.2.tgz",
+      "integrity": "sha512-kbso5+pd6tIwmnTidQfEQ5nRydYw4+8I+8h19yIG/RWcRi8H4TCLlBHwAFBDAmLE4dTkPkctpQQSP8x1nMyYqw==",
+      "dev": true,
+      "requires": {
+        "@babel/polyfill": "^7.0.0-beta.51",
+        "bluebird": "^3.5.1",
+        "chalk": "^2.1.0",
+        "chokidar": "^2.0.0",
+        "debug": "^3.0.1",
+        "keypress": "^0.2.1",
+        "lodash": "^4.17.4",
+        "optionator": "^0.8.2",
+        "source-map-support": "^0.5.3",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "unicons": "0.0.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.11",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+          "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "espree": {
       "version": "5.0.1",
@@ -5013,6 +5119,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
@@ -5341,8 +5453,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5360,13 +5471,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5379,18 +5488,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5493,8 +5599,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5504,7 +5609,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5517,20 +5621,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5547,7 +5648,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5620,8 +5720,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5631,7 +5730,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5707,8 +5805,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5738,7 +5835,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5756,7 +5852,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5795,13 +5890,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -6544,14 +6637,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.2.tgz",
       "integrity": "sha512-Mps0898zEduHyPhb7UCgNmfzlqNZknVmaFz5qzr0mm04YQ5FGLhAyK/dJ+NaRxGyR6juQXIxh5Ev0xx+qq0nYA==",
-      "requires": {
-        "symbol-observable": "1.2.0"
-      }
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
         "symbol-observable": "1.2.0"
       }
@@ -8602,6 +8687,12 @@
       "requires": {
         "array-includes": "^3.0.3"
       }
+    },
+    "keypress": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
+      "integrity": "sha1-HoBFQlABjbrUw/6USX1uZ7YmnHc=",
+      "dev": true
     },
     "killable": {
       "version": "1.0.1",
@@ -12627,6 +12718,12 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
@@ -13123,16 +13220,6 @@
         "warning": "^4.0.1"
       }
     },
-    "react-event-listener": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.6.tgz",
-      "integrity": "sha512-+hCNqfy7o9wvO6UgjqFmBzARJS7qrNoda0VqzvOuioEpoEXKutiKuv92dSz6kP7rYLmyHPyYNLesi5t/aH1gfw==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "prop-types": "^15.6.0",
-        "warning": "^4.0.1"
-      }
-    },
     "react-immutable-proptypes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
@@ -13150,11 +13237,6 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
       "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -13763,15 +13845,9 @@
       }
     },
     "react-transition-group": {
-<<<<<<< HEAD
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.6.1.tgz",
-      "integrity": "sha512-9DHwCy0aOYEe35frlEN68N9ut/THDQBLnVoQuKTvzF4/s3tk7lqkefCqxK2Nv96fOh6JXk6tQtliygk6tl3bQA==",
-=======
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.6.0.tgz",
       "integrity": "sha512-VzZ+6k/adL3pJHo4PU/MHEPjW59/TGQtRsXC+wnxsx2mxjQKNHnDdJL/GpYuPJIsyHGjYbBQfIJ2JNOAdPc8GQ==",
->>>>>>> WIP - datepicker styling
       "requires": {
         "dom-helpers": "^3.3.1",
         "loose-envify": "^1.4.0",
@@ -15692,6 +15768,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
+    },
+    "unicons": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/unicons/-/unicons-0.0.3.tgz",
+      "integrity": "sha1-bmp6Gm6uuwHKPYsSrZaHJ56rpSQ=",
+      "dev": true
     },
     "unified": {
       "version": "7.1.0",

--- a/frontend/src/components/utils/plastic.js
+++ b/frontend/src/components/utils/plastic.js
@@ -36,7 +36,7 @@ export const plasticOptions = [
     value: 'clear_pet', // deprecated option
     label: 'Clear PET',
     imageLink: bottleImage,
-    buy: false,
+    buy: true,
     sell: false,
   },
   {


### PR DESCRIPTION
Add a plastic type map - previously the plastic type value in the podio request was hardcoded. This PR adds a mapping from our plastic type enums to podio's buy and sell plastic type ids.

Change highlights:
* Add podio_mapping.py as a model, which stores the static mapping between our enums to all plastic types supported by podio. Note that podio sourcing table schema uses an enum while podio buy transaction table schema uses a plastic type table (so each type corresponds to an item id).
* Replace the previously hardcoded value with the corresponding mapping value. If the enum is not supported by podio, the podio request will not be sent, an error will be logged, but there will be no exception raised.

Test:
* Works for both buy and sell transactions